### PR TITLE
Resolve failing builds

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0' # Not needed with a .ruby-version file
+          ruby-version: '3.2' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Install Jekyll
-        run: gem install jekyll bundler github-pages jekyll-paginate
+        run: gem install bundler github-pages jekyll-paginate
 
       - name: Jekyll build
         run: jekyll build


### PR DESCRIPTION
Resolve issue #25 failing builds and blocking changes to production website.

- [x] Remove redundant `gem install jekyll` per [GitHub/github-pages] readme
- [x] Upgrade to Ruby 3.2