### PR TITLE
fix: skip dependabot preview deploy

### DIFF
--- a/.github/workflows/bosterdev-deploy.yml
+++ b/.github/workflows/bosterdev-deploy.yml
@@ -59,6 +59,7 @@ jobs:
         run: scripts/test-and-preview.sh --check-only
 
       - name: Build And Deploy
+        if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:

--- a/test/repository_contract.bats
+++ b/test/repository_contract.bats
@@ -14,6 +14,10 @@ load "helpers/bats_setup.bash"
   assert_file_contains ".github/workflows/bosterdev-deploy.yml" "ruby-version: '3.2'"
 }
 
+@test "workflow skips Azure preview deployment for Dependabot pull requests" {
+  assert_file_contains ".github/workflows/bosterdev-deploy.yml" "github.actor != 'dependabot[bot]'"
+}
+
 @test "dependabot monitors GitHub Actions and Bundler dependencies" {
   assert_file_contains ".github/dependabot.yml" "package-ecosystem: \"github-actions\""
   assert_file_contains ".github/dependabot.yml" "package-ecosystem: \"bundler\""


### PR DESCRIPTION
## Summary

- Skips only the Azure Static Web Apps deploy step for Dependabot pull requests.
- Keeps the verification script running for Dependabot PRs, so build/BATS coverage still gates dependency updates.
- Adds a BATS contract assertion for the Dependabot deploy guard.

## Root Cause

PRs #40 and #41 both pass the site verification script, then fail in Azure Static Web Apps preview deployment with `No matching Static Web App was found or the api key was invalid.` Dependabot PR runs do not have a usable Azure deployment token for that preview step.

## Verification

- [x] `scripts/test-and-preview.sh --check-only`
- [x] `git diff --check`

## Unblocks

- #40
- #41