### PR TITLE
feat: add crawler discovery files

### DIFF
--- a/src/boster.dev/_config.yml
+++ b/src/boster.dev/_config.yml
@@ -3,8 +3,10 @@ theme: jekyll-theme-architect
 title: Dave Boster
 email: david@boster.us
 description: How Fascinating! ＼(๏◡๏)／
+url: "https://boster.dev"
 twitter_username: davidboster
 github_username: daveboster
+repository: daveboster/daveboster.github.io
 
 collections:
   thoughts:

--- a/src/boster.dev/_layouts/default.html
+++ b/src/boster.dev/_layouts/default.html
@@ -4,7 +4,8 @@
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}" media="screen" type="text/css">
+    {% assign cache_buster = site.time | date: "%s" %}
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: cache_buster | relative_url }}" media="screen" type="text/css">
     <link rel="stylesheet" href="{{ '/assets/css/print.css' | relative_url }}" media="print" type="text/css">
     <link href="https://github.com/daveboster" rel="me">
     <link href="https://boster.dev/" rel="me">
@@ -22,14 +23,11 @@
     <header>
       <div class="inner">
         <a href="{{ '/' | absolute_url }}">
-          <h1>{{ site.title | default: site.github.repository_name }}</h1>
+          <h1>{{ site.title | default: "Dave Boster" }}</h1>
         </a>
-        <h2>{{ site.description | default: site.github.project_tagline }}</h2>
-        {% if site.github.is_project_page %}
-          <a href="{{ site.github.repository_url }}" class="button"><small>View project on</small> GitHub</a>
-        {% endif %}
-        {% if site.github.is_user_page %}
-          <a href="{{ site.github.owner_url }}" class="button"><small>Follow me on</small> GitHub</a>
+        <h2>{{ site.description }}</h2>
+        {% if site.github_username %}
+          <a href="https://github.com/{{ site.github_username }}" class="button"><small>Follow me on</small> GitHub</a>
         {% endif %}
       </div>
     </header>
@@ -46,12 +44,12 @@
             <li><a href="/thoughts/" class="page-link">Thoughts</a></li>
           </ul>
           
-          {% if site.show_downloads %}
-            <a href="{{ site.github.zip_url }}" class="button">
+          {% if site.show_downloads and site.repository %}
+            <a href="https://github.com/{{ site.repository }}/archive/refs/heads/main.zip" class="button">
               <small>Download</small>
               .zip file
             </a>
-            <a href="{{ site.github.tar_url }}" class="button">
+            <a href="https://github.com/{{ site.repository }}/archive/refs/heads/main.tar.gz" class="button">
               <small>Download</small>
               .tar.gz file
             </a>

--- a/src/boster.dev/robots.txt
+++ b/src/boster.dev/robots.txt
@@ -1,0 +1,8 @@
+---
+layout: null
+permalink: /robots.txt
+---
+User-agent: *
+Allow: /
+
+Sitemap: {{ "/sitemap.xml" | absolute_url }}

--- a/src/boster.dev/sitemap.xml
+++ b/src/boster.dev/sitemap.xml
@@ -1,0 +1,28 @@
+---
+layout: null
+permalink: /sitemap.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% assign sitemap_pages = site.pages | where_exp: "item", "item.sitemap != false" %}
+  {% for item in sitemap_pages %}
+    {% unless item.url contains ".xml" or item.url contains ".txt" or item.url contains "/assets/" %}
+  <url>
+    <loc>{{ item.url | absolute_url | xml_escape }}</loc>
+    {% if item.date %}<lastmod>{{ item.date | date_to_xmlschema }}</lastmod>{% endif %}
+  </url>
+    {% endunless %}
+  {% endfor %}
+  {% for item in site.posts %}
+  <url>
+    <loc>{{ item.url | absolute_url | xml_escape }}</loc>
+    <lastmod>{{ item.date | date_to_xmlschema }}</lastmod>
+  </url>
+  {% endfor %}
+  {% for item in site.thoughts %}
+  <url>
+    <loc>{{ item.url | absolute_url | xml_escape }}</loc>
+    {% if item.date %}<lastmod>{{ item.date | date_to_xmlschema }}</lastmod>{% endif %}
+  </url>
+  {% endfor %}
+</urlset>

--- a/test/helpers/bats_setup.bash
+++ b/test/helpers/bats_setup.bash
@@ -29,3 +29,15 @@ assert_file_contains() {
     return 1
   fi
 }
+
+refute_file_contains() {
+  local path="$1"
+  local unexpected="$2"
+  local full_path
+  full_path="$(fixture_path "$path")"
+
+  if grep -Fq "$unexpected" "$full_path"; then
+    echo "Expected $path not to contain: $unexpected" >&2
+    return 1
+  fi
+}

--- a/test/repository_contract.bats
+++ b/test/repository_contract.bats
@@ -18,6 +18,20 @@ load "helpers/bats_setup.bash"
   assert_file_contains ".github/workflows/bosterdev-deploy.yml" "github.actor != 'dependabot[bot]'"
 }
 
+@test "site publishes crawler discovery endpoints" {
+  assert_file_contains "src/boster.dev/_config.yml" "url: \"https://boster.dev\""
+  assert_file_contains "src/boster.dev/_config.yml" "repository: daveboster/daveboster.github.io"
+  assert_file_exists "src/boster.dev/robots.txt"
+  assert_file_exists "src/boster.dev/sitemap.xml"
+  assert_file_contains "src/boster.dev/robots.txt" "Sitemap: {{ \"/sitemap.xml\" | absolute_url }}"
+  assert_file_contains "src/boster.dev/sitemap.xml" "http://www.sitemaps.org/schemas/sitemap/0.9"
+  assert_file_contains "src/boster.dev/sitemap.xml" "item.url contains \"/assets/\""
+}
+
+@test "layout does not require GitHub metadata at build time" {
+  refute_file_contains "src/boster.dev/_layouts/default.html" "site.github."
+}
+
 @test "dependabot monitors GitHub Actions and Bundler dependencies" {
   assert_file_contains ".github/dependabot.yml" "package-ecosystem: \"github-actions\""
   assert_file_contains ".github/dependabot.yml" "package-ecosystem: \"bundler\""


### PR DESCRIPTION
## Summary
- Add Jekyll-rendered robots.txt and sitemap.xml for boster.dev
- Set the canonical site url and repository metadata in _config.yml
- Remove layout references to site.github.* so local builds do not block on GitHub Metadata network checks
- Add BATS coverage for the crawler endpoints and metadata-free layout contract

## Verification
- [x] scripts/test-and-preview.sh --check-only
- [x] Rendered robots.txt points to https://boster.dev/sitemap.xml
- [x] Rendered sitemap lists page/post/thought URLs without asset URLs

## Notes
- The build still emits the pre-existing YAML warnings for tag/github-pages.md and tag/jekyll-posts.md; those are tracked separately in #37.

Closes #34