### PR TITLE
feat: add site quality audit

### DIFF
--- a/docs/audits/2026-06-23-site-quality-audit.md
+++ b/docs/audits/2026-06-23-site-quality-audit.md
@@ -1,0 +1,59 @@
+# Site Quality Audit - 2026-06-23
+
+## Scope
+
+This audit covers the repeatable quality checks from the website next-steps
+list:
+
+- internal link checking
+- optional external link checking
+- basic accessibility checks
+- basic SEO and metadata checks
+
+## Changes Made
+
+- Added `scripts/audit-site-quality.sh` for rendered-site checks.
+- Added the audit script to `scripts/test-and-preview.sh --check-only` so CI
+  covers internal links, metadata, and accessibility basics.
+- Added missing tag pages for every published post and thought tag.
+- Updated tag links to point to the generated `.html` tag pages.
+- Updated the tag page layout to list matching thoughts as well as posts.
+- Replaced the homepage Dave Farley link because `www.davefarley.net` currently
+  has an expired TLS certificate.
+
+## Current Results
+
+Command:
+
+```bash
+scripts/test-and-preview.sh --check-only
+```
+
+Result:
+
+- Jekyll build passed.
+- Site quality audit passed for 39 HTML files.
+- 612 internal references resolved.
+- 29 external links were skipped in the default offline audit.
+- BATS passed.
+- `git diff --check` passed.
+
+Command:
+
+```bash
+scripts/audit-site-quality.sh --skip-build --external-links
+```
+
+Result:
+
+- External link audit passed for 29 external links.
+- `https://brenebrown.com` returned HTTP 403 to the automated checker. This is
+  recorded as a warning because the host appears to block scripted checks rather
+  than indicating a missing page.
+
+## Follow-Up
+
+- Consider adding a fuller accessibility tool such as axe or Pa11y later if the
+  site grows beyond static content and simple layouts.
+- Recheck external links periodically because they are intentionally not part of
+  the default CI path.

--- a/docs/codex/workstation-setup.md
+++ b/docs/codex/workstation-setup.md
@@ -63,6 +63,20 @@ To run the checks without starting the preview server:
 scripts/test-and-preview.sh --check-only
 ```
 
+That command also runs the offline site quality audit for internal links,
+metadata, and accessibility basics. To run the audit directly:
+
+```bash
+scripts/audit-site-quality.sh --skip-build
+```
+
+External links are intentionally opt-in so local and CI checks do not depend on
+third-party availability:
+
+```bash
+scripts/audit-site-quality.sh --skip-build --external-links
+```
+
 The manual build commands are:
 
 ```bash

--- a/scripts/audit-site-quality.sh
+++ b/scripts/audit-site-quality.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+site_dir="$repo_root/src/boster.dev"
+site_output="$site_dir/_site"
+base_url="https://boster.dev"
+skip_build=0
+check_external=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/audit-site-quality.sh [options]
+
+Audits the generated Jekyll site for basic link, metadata, and accessibility
+contracts.
+
+Default checks:
+  bundle exec jekyll build
+  internal href/src references resolve inside _site
+  HTML pages have lang, viewport, title, canonical, description, and h1
+  images have alt text
+
+Options:
+  --skip-build       Audit the existing src/boster.dev/_site output.
+  --external-links   Also check external HTTP/HTTPS links over the network.
+  --base-url URL     Site base URL for canonical/internal checks.
+                    Default: https://boster.dev
+  -h, --help         Show this help text.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-build)
+      skip_build=1
+      shift
+      ;;
+    --external-links)
+      check_external=1
+      shift
+      ;;
+    --base-url)
+      base_url="${2:?--base-url requires a value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+run() {
+  echo "+ $*"
+  "$@"
+}
+
+if [[ "$skip_build" -eq 0 ]]; then
+  cd "$site_dir"
+  run bundle exec jekyll build
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for the site quality audit." >&2
+  exit 69
+fi
+
+python3 - "$site_output" "$base_url" "$check_external" <<'PY'
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urljoin, urlparse, unquote
+import sys
+import urllib.error
+import urllib.request
+
+site_output = Path(sys.argv[1]).resolve()
+base_url = sys.argv[2].rstrip("/") + "/"
+check_external = sys.argv[3] == "1"
+base_host = urlparse(base_url).netloc
+
+
+class PageParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.html_lang = False
+        self.title = ""
+        self.in_title = False
+        self.viewport = False
+        self.description = False
+        self.canonical = False
+        self.meta_refresh = False
+        self.h1_count = 0
+        self.images_missing_alt = []
+        self.references = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs = {name.lower(): value for name, value in attrs}
+
+        if tag == "html" and attrs.get("lang", "").strip():
+            self.html_lang = True
+        elif tag == "title":
+            self.in_title = True
+        elif tag == "meta":
+            name = attrs.get("name", "").lower()
+            http_equiv = attrs.get("http-equiv", "").lower()
+            if name == "viewport" and attrs.get("content", "").strip():
+                self.viewport = True
+            if name == "description" and attrs.get("content", "").strip():
+                self.description = True
+            if http_equiv == "refresh":
+                self.meta_refresh = True
+        elif tag == "link":
+            if attrs.get("rel", "").lower() == "canonical" and attrs.get("href", "").strip():
+                self.canonical = True
+        elif tag == "h1":
+            self.h1_count += 1
+        elif tag == "img":
+            alt = attrs.get("alt")
+            if alt is None or not alt.strip():
+                self.images_missing_alt.append(attrs.get("src", "<missing src>"))
+
+        for attr in ("href", "src"):
+            value = attrs.get(attr)
+            if value:
+                self.references.append((tag, attr, value.strip()))
+
+    def handle_endtag(self, tag):
+        if tag == "title":
+            self.in_title = False
+
+    def handle_data(self, data):
+        if self.in_title:
+            self.title += data
+
+
+def page_url(path):
+    rel = path.relative_to(site_output).as_posix()
+    if rel == "index.html":
+        return base_url
+    if rel.endswith("/index.html"):
+        return urljoin(base_url, rel[:-10] + "/")
+    return urljoin(base_url, rel)
+
+
+def internal_target_exists(path):
+    parsed = urlparse(path)
+    raw_path = unquote(parsed.path)
+    if not raw_path or raw_path == "/":
+        return (site_output / "index.html").is_file()
+
+    rel_path = raw_path.lstrip("/")
+    candidate = site_output / rel_path
+
+    if raw_path.endswith("/"):
+        return (candidate / "index.html").is_file()
+
+    if candidate.is_file():
+        return True
+
+    if candidate.is_dir() and (candidate / "index.html").is_file():
+        return True
+
+    return False
+
+
+def classify_reference(current_url, value):
+    if not value or value.startswith("#"):
+        return ("ignored", value)
+
+    parsed = urlparse(value)
+    if parsed.scheme in {"mailto", "tel", "javascript", "data"}:
+        return ("ignored", value)
+
+    absolute = urljoin(current_url, value)
+    parsed_absolute = urlparse(absolute)
+
+    if parsed_absolute.scheme in {"http", "https"} and parsed_absolute.netloc != base_host:
+        return ("external", absolute)
+
+    if parsed_absolute.scheme in {"http", "https"}:
+        return ("internal", parsed_absolute.path or "/")
+
+    return ("ignored", value)
+
+
+def check_external_url(url):
+    headers = {"User-Agent": "boster.dev site quality audit"}
+    for method in ("HEAD", "GET"):
+        request = urllib.request.Request(url, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=15) as response:
+                status = response.getcode()
+                if status < 400:
+                    return None
+                return f"{url} returned HTTP {status}"
+        except urllib.error.HTTPError as error:
+            if method == "HEAD" and error.code in {403, 405}:
+                continue
+            if error.code == 403:
+                return f"warning: {url} returned HTTP 403; host may block automated checks"
+            return f"{url} returned HTTP {error.code}"
+        except Exception as error:
+            if method == "HEAD":
+                continue
+            return f"{url} failed: {error}"
+    return None
+
+
+errors = []
+warnings = []
+html_files = sorted(site_output.rglob("*.html"))
+internal_reference_count = 0
+external_urls = set()
+
+if not html_files:
+    errors.append(f"No HTML files found in {site_output}")
+
+for path in html_files:
+    parser = PageParser()
+    text = path.read_text(encoding="utf-8")
+    parser.feed(text)
+    rel = path.relative_to(site_output).as_posix()
+    redirect_page = parser.meta_refresh
+
+    if not parser.html_lang:
+        errors.append(f"{rel}: missing html lang")
+    if not parser.title.strip():
+        errors.append(f"{rel}: missing title")
+    if not redirect_page and not parser.viewport:
+        errors.append(f"{rel}: missing viewport meta")
+    if not parser.canonical:
+        errors.append(f"{rel}: missing canonical link")
+    if not redirect_page and not parser.description:
+        errors.append(f"{rel}: missing meta description")
+    if not redirect_page and parser.h1_count == 0:
+        errors.append(f"{rel}: missing h1")
+
+    for src in parser.images_missing_alt:
+        errors.append(f"{rel}: image missing alt text: {src}")
+
+    current_url = page_url(path)
+    for tag, attr, value in parser.references:
+        kind, target = classify_reference(current_url, value)
+        if kind == "internal":
+            internal_reference_count += 1
+            if not internal_target_exists(target):
+                errors.append(f"{rel}: {tag}[{attr}] points to missing internal target: {value}")
+        elif kind == "external":
+            external_urls.add(target)
+
+if check_external:
+    for url in sorted(external_urls):
+        error = check_external_url(url)
+        if error:
+            if error.startswith("warning: "):
+                warnings.append(error.removeprefix("warning: "))
+            else:
+                errors.append(error)
+
+if errors:
+    print("Site quality audit failed:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    sys.exit(1)
+
+if warnings:
+    print("Site quality audit warnings:", file=sys.stderr)
+    for warning in warnings:
+        print(f"- {warning}", file=sys.stderr)
+
+external_note = f"{len(external_urls)} external links skipped"
+if check_external:
+    external_note = f"{len(external_urls)} external links checked"
+
+print(
+    "Site quality audit passed: "
+    f"{len(html_files)} HTML files, "
+    f"{internal_reference_count} internal references, "
+    f"{external_note}."
+)
+PY

--- a/scripts/test-and-preview.sh
+++ b/scripts/test-and-preview.sh
@@ -21,6 +21,7 @@ Runs the local verification flow, then starts the Jekyll preview server.
 Verification flow:
   bundle install
   bundle exec jekyll build
+  scripts/audit-site-quality.sh --skip-build
   bats test
   git diff --check
 
@@ -131,6 +132,7 @@ fi
 run bundle exec jekyll build
 
 cd "$repo_root"
+run scripts/audit-site-quality.sh --skip-build
 run bats test
 run git diff --check
 

--- a/src/boster.dev/_includes/archive.html
+++ b/src/boster.dev/_includes/archive.html
@@ -8,5 +8,5 @@
 {% for temptag in sortedtemptags %}
   {% assign tagitems = temptag | split: '#' %}
   {% capture tagname %}{{ tagitems[1] }}{% endcapture %}
-  <a href="/tag/{{ tagname }}"><code class="highlighter-rouge"><nobr>{{ tagname }}</nobr></code></a>
+  <a href="{{ '/tag/' | append: tagname | append: '.html' | relative_url }}"><code class="highlighter-rouge"><nobr>{{ tagname }}</nobr></code></a>
 {% endfor %}

--- a/src/boster.dev/_layouts/post.html
+++ b/src/boster.dev/_layouts/post.html
@@ -11,6 +11,6 @@ layout: default
 <span>[
   {% for tag in page.tags %}
     {% capture tag_name %}{{ tag }}{% endcapture %}
-    <a href="/tag/{{ tag_name }}"><code class="highlighter-rouge"><nobr>{{ tag_name }}</nobr></code>&nbsp;</a>
+    <a href="{{ '/tag/' | append: tag_name | append: '.html' | relative_url }}"><code class="highlighter-rouge"><nobr>{{ tag_name }}</nobr></code>&nbsp;</a>
   {% endfor %}
 ]</span>

--- a/src/boster.dev/_layouts/tagpage.html
+++ b/src/boster.dev/_layouts/tagpage.html
@@ -9,6 +9,12 @@ layout: default
     {{ post.description }}
   </li>
 {% endfor %}
+{% assign tagged_thoughts = site.thoughts | where_exp: "thought", "thought.tags contains page.tag" %}
+{% for thought in tagged_thoughts %}
+  <li><a href="{{ thought.url }}">{{ thought.title }}</a>{% if thought.date %} ({{ thought.date | date_to_string }}){% endif %}<br>
+    {{ thought.description }}
+  </li>
+{% endfor %}
 </ul>
 </div>
 <hr>

--- a/src/boster.dev/_layouts/thought.html
+++ b/src/boster.dev/_layouts/thought.html
@@ -11,6 +11,6 @@ layout: default
 <span>[
   {% for tag in page.tags %}
     {% capture tag_name %}{{ tag }}{% endcapture %}
-    <a href="/tag/{{ tag_name }}"><code class="highlighter-rouge"><nobr>{{ tag_name }}</nobr></code>&nbsp;</a>
+    <a href="{{ '/tag/' | append: tag_name | append: '.html' | relative_url }}"><code class="highlighter-rouge"><nobr>{{ tag_name }}</nobr></code>&nbsp;</a>
   {% endfor %}
 ]</span>

--- a/src/boster.dev/blog/index.html
+++ b/src/boster.dev/blog/index.html
@@ -35,6 +35,6 @@ title: Dave's Blog
 <span>[
   {% for tag in page.tags %}
     {% capture tag_name %}{{ tag }}{% endcapture %}
-    <a href="/tag/{{ tag_name }}"><code class="highlighter-rouge"><nobr>{{ tag_name }}</nobr></code>&nbsp;</a>
+    <a href="{{ '/tag/' | append: tag_name | append: '.html' | relative_url }}"><code class="highlighter-rouge"><nobr>{{ tag_name }}</nobr></code>&nbsp;</a>
   {% endfor %}
 ]</span>

--- a/src/boster.dev/index.md
+++ b/src/boster.dev/index.md
@@ -11,7 +11,7 @@ I like to dream big, try some impossible things, collaborate and share with othe
 
 I’m a curious and passionate professional software developer [manager] looking to help guide software development and the use of technology, particularly within healthcare, so to help us be more *human*, more *effective*, and more *intentional*! I am committed to continual improvement and helping other software professionals through the relentless pursuit of mastery in Clean Coding practices and the Extreme Programming (XP) principles of Test-Driven Development (TDD), Refactoring, Pairing, and Simple Design.
 
-My favorite leaders whose works I continue study today include thought leaders like [Jim Collins](https://www.jimcollins.com), [Brené Brown](https://brenebrown.com), [Simon Sinek](https://simonsinek.com), and [Jocko Willink](https://jocko.com); software visionaries like [Uncle Bob (Robert C. Martin)](https://cleancoders.com), [Scott Hanselman](https://www.hanselman.com), and [Dave Farley](https://www.davefarley.net).
+My favorite leaders whose works I continue study today include thought leaders like [Jim Collins](https://www.jimcollins.com), [Brené Brown](https://brenebrown.com), [Simon Sinek](https://simonsinek.com), and [Jocko Willink](https://jocko.com); software visionaries like [Uncle Bob (Robert C. Martin)](https://cleancoders.com), [Scott Hanselman](https://www.hanselman.com), and [Dave Farley](https://continuousdelivery.com).
 
 ## Why this website?
 

--- a/src/boster.dev/tag/about-me.md
+++ b/src/boster.dev/tag/about-me.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: about-me"
+tag: about-me
+---

--- a/src/boster.dev/tag/agile.md
+++ b/src/boster.dev/tag/agile.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: agile"
+tag: agile
+---

--- a/src/boster.dev/tag/build-pipelines.md
+++ b/src/boster.dev/tag/build-pipelines.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: build-pipelines"
+tag: build-pipelines
+---

--- a/src/boster.dev/tag/communication.md
+++ b/src/boster.dev/tag/communication.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: communication"
+tag: communication
+---

--- a/src/boster.dev/tag/competency-matrix.md
+++ b/src/boster.dev/tag/competency-matrix.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: competency-matrix"
+tag: competency-matrix
+---

--- a/src/boster.dev/tag/developer-blogs.md
+++ b/src/boster.dev/tag/developer-blogs.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: developer-blogs"
+tag: developer-blogs
+---

--- a/src/boster.dev/tag/developer-quote.md
+++ b/src/boster.dev/tag/developer-quote.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: developer-quote"
+tag: developer-quote
+---

--- a/src/boster.dev/tag/developer.md
+++ b/src/boster.dev/tag/developer.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: developer"
+tag: developer
+---

--- a/src/boster.dev/tag/development-management.md
+++ b/src/boster.dev/tag/development-management.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: development-management"
+tag: development-management
+---

--- a/src/boster.dev/tag/development-process.md
+++ b/src/boster.dev/tag/development-process.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: development-process"
+tag: development-process
+---

--- a/src/boster.dev/tag/education.md
+++ b/src/boster.dev/tag/education.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: education"
+tag: education
+---

--- a/src/boster.dev/tag/engineering-leadership.md
+++ b/src/boster.dev/tag/engineering-leadership.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: engineering-leadership"
+tag: engineering-leadership
+---

--- a/src/boster.dev/tag/extreme-programming.md
+++ b/src/boster.dev/tag/extreme-programming.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: extreme-programming"
+tag: extreme-programming
+---

--- a/src/boster.dev/tag/government.md
+++ b/src/boster.dev/tag/government.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: government"
+tag: government
+---

--- a/src/boster.dev/tag/healthcare.md
+++ b/src/boster.dev/tag/healthcare.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: healthcare"
+tag: healthcare
+---

--- a/src/boster.dev/tag/honing-craft.md
+++ b/src/boster.dev/tag/honing-craft.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: honing-craft"
+tag: honing-craft
+---

--- a/src/boster.dev/tag/leadership.md
+++ b/src/boster.dev/tag/leadership.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: leadership"
+tag: leadership
+---

--- a/src/boster.dev/tag/learning.md
+++ b/src/boster.dev/tag/learning.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: learning"
+tag: learning
+---

--- a/src/boster.dev/tag/programmers-oath.md
+++ b/src/boster.dev/tag/programmers-oath.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: programmers-oath"
+tag: programmers-oath
+---

--- a/src/boster.dev/tag/quote-origin.md
+++ b/src/boster.dev/tag/quote-origin.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: quote-origin"
+tag: quote-origin
+---

--- a/src/boster.dev/tag/software-professional.md
+++ b/src/boster.dev/tag/software-professional.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: software-professional"
+tag: software-professional
+---

--- a/src/boster.dev/tag/tech-talks.md
+++ b/src/boster.dev/tag/tech-talks.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: tech-talks"
+tag: tech-talks
+---

--- a/src/boster.dev/tag/technology.md
+++ b/src/boster.dev/tag/technology.md
@@ -1,0 +1,5 @@
+---
+layout: tagpage
+title: "Topic: technology"
+tag: technology
+---

--- a/src/boster.dev/thoughts/index.html
+++ b/src/boster.dev/thoughts/index.html
@@ -17,7 +17,7 @@ title: Thoughts
     <span>[
       {% for tag in thought.tags %}
         {% capture tag_name %}{{ tag }}{% endcapture %}
-        <a href="/tag/{{ tag_name }}"><code class="highlighter-rouge"><nobr>{{ tag_name }}</nobr></code>&nbsp;</a>
+        <a href="{{ '/tag/' | append: tag_name | append: '.html' | relative_url }}"><code class="highlighter-rouge"><nobr>{{ tag_name }}</nobr></code>&nbsp;</a>
       {% endfor %}
     ]</span>
 

--- a/test/repository_contract.bats
+++ b/test/repository_contract.bats
@@ -65,12 +65,25 @@ load "helpers/bats_setup.bash"
 
 @test "test and preview script documents the local verification flow" {
   assert_file_exists "scripts/test-and-preview.sh"
+  assert_file_exists "scripts/audit-site-quality.sh"
   assert_file_contains "docs/codex/workstation-setup.md" "scripts/test-and-preview.sh"
+  assert_file_contains "docs/codex/workstation-setup.md" "scripts/audit-site-quality.sh --skip-build"
+  assert_file_contains "scripts/test-and-preview.sh" "scripts/audit-site-quality.sh --skip-build"
 
   run "$(fixture_path "scripts/test-and-preview.sh")" --help
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"bundle exec jekyll build"* ]]
+  [[ "$output" == *"scripts/audit-site-quality.sh --skip-build"* ]]
   [[ "$output" == *"bats test"* ]]
   [[ "$output" == *"bundle exec jekyll serve"* ]]
+}
+
+@test "site quality audit script documents offline and external checks" {
+  run "$(fixture_path "scripts/audit-site-quality.sh")" --help
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--skip-build"* ]]
+  [[ "$output" == *"--external-links"* ]]
+  [[ "$output" == *"internal href/src references resolve"* ]]
 }


### PR DESCRIPTION
## Summary
- Add scripts/audit-site-quality.sh for rendered HTML quality checks
- Run the offline quality audit from scripts/test-and-preview.sh --check-only
- Fix broken tag links by adding tag pages for published tags and linking to generated .html files
- Include matching thoughts on tag pages, not just posts
- Replace the homepage Dave Farley link because the old host currently has an expired TLS certificate
- Document the 2026-06-23 site quality audit results

## Verification
- [x] scripts/test-and-preview.sh --check-only
- [x] scripts/audit-site-quality.sh --skip-build --external-links

## External link note
The external audit passes but reports https://brenebrown.com as a warning because Cloudflare returns HTTP 403 to automated checks.